### PR TITLE
remove all nixpkgs channels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,11 @@ RUN nix-channel --add \
 RUN nix-env -iA \
   nixpkgs.bashInteractive nixpkgs.coreutils nixpkgs.cacert
 
-RUN nix-collect-garbage -d
+# Remove old things
+RUN \
+  nix-channel --remove nixpkgs && \
+  rm -rf /nix/store/*-nixpkgs* && \
+  nix-collect-garbage -d
 
 # Fixes root login shell
 RUN sed -e "s|/bin/ash|/bin/bash|g" -i /etc/passwd


### PR DESCRIPTION
nixpkgs is taking a lot of space on the image and is likely not to be
used by the user if he pins his dependencies properly.

| | Compressed | Uncompressed |
| - | - | - |
| *Before* | 81 MB | 225MB |
| *After* | 43 MB | 112MB |

This will break existing builds if they rely on the channel already.
