### PR TITLE
add xz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN nix-env -iA \
   nixpkgs.coreutils \
   nixpkgs.gnutar \
   nixpkgs.gzip \
+  nixpkgs.xz \
   && true
 
 # Remove old things

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ RUN \
   rm -rf /nix/store/*-nixpkgs* && \
   nix-collect-garbage -d
 
+# Fixes missing hashes
+RUN nix-store --verify --check-contents
+
 # Fixes root login shell
 RUN sed -e "s|/bin/ash|/bin/bash|g" -i /etc/passwd
 


### PR DESCRIPTION
Nix is depending on xz to unpack the channels. Eg:

    nix run -f channel:nixos-18.03 gnugrep

This is necessary since we're not shipping a default channel anymore.