### PR TITLE
Disable the sandbox via nix.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,4 +68,7 @@ ENV \
     NIX_SSL_CERT_FILE=/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt \
     NIX_PATH=/nix/var/nix/profiles/per-user/root/channels
 
+# The sandbox requires privileged docker containers
+RUN mkdir -p /etc/nix && echo sandbox = false > /etc/nix/nix.conf
+
 CMD "bash"


### PR DESCRIPTION
Nix 2.2 enables the sandbox by default on Linux platforms. For sandbox build support the image would need to be run in privileged containers which we should not require by default.

Before this PR:
```
# nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs
# nix-channel --update
unpacking channels...
error: cloning builder process: Operation not permitted
error: unable to start build process
error: program '/nix/store/5hdmx9yk7gr71b98j4vh9271k0zg5jis-nix-2.2.1/bin/nix-env' failed with exit code 1
```

After this PR:
```
# nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs
# nix-channel --update
unpacking channels...
created 2 symlinks in user environment
```